### PR TITLE
Fix tag being treated as segment

### DIFF
--- a/lib/jellygrinder/client/hls.ex
+++ b/lib/jellygrinder/client/hls.ex
@@ -89,6 +89,7 @@ defmodule Jellygrinder.Client.HLS do
   defp get_last_segment(track_manifest) do
     track_manifest
     |> String.split("\n", trim: true)
+    |> Enum.reject(&String.starts_with?(&1, "#"))
     |> List.last()
   end
 


### PR DESCRIPTION
When running lots of HLS clients, I've had them make these kinds of requests:
```
http://REDACTED:5002/hls/96f69720-ab61-4499-9d29-50d61dd48a8f/#EXT-X-PROGRAM-DATE-TIME
http://REDACTED:5002/hls/96f69720-ab61-4499-9d29-50d61dd48a8f/#EXT-X-PROGRAM-DATE-TIME:2023-10-20T09:28:28.123Z
```

It seems we sometimes requested the track manifest file in the exact moment that it was written, and the last line was a tag. These cases are rare (0,001% of all requests in that particular test), but handling them is easy, so let's do it